### PR TITLE
Error fix. Cannot find property match of null

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -13,7 +13,7 @@ issuesUrl = (info) ->
 getOriginURL = -> atom.project.getRepositories()[0]?.getOriginURL() or null
 
 isGitHubRepo = ->
-  return false unless getOriginURL
+  return false unless getOriginURL()
   m = getOriginURL().match GH_REGEX
   if m
     {


### PR DESCRIPTION
If the project opened on atom, was not a github repo, then it was throwing an error with the message 'Cannot find property match of null'. This fixes this error and prints the correct message when it tries to retrieves its issues
